### PR TITLE
Match Process timeout to Composer global timeout

### DIFF
--- a/src/Composer/Command/ProcessCommand.php
+++ b/src/Composer/Command/ProcessCommand.php
@@ -26,6 +26,10 @@ use ReflectionException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
+use function filter_var;
+
+use const FILTER_VALIDATE_FLOAT;
+
 abstract class ProcessCommand extends BaseCommand
 {
     /**
@@ -49,6 +53,8 @@ abstract class ProcessCommand extends BaseCommand
             $this->getProcessCommand($input, $output),
             $this->getConfiguration()->getRepositoryRoot(),
         );
+        $composerTimeout = $this->getConfiguration()->getComposer()->getConfig()->get('process-timeout');
+        $process->setTimeout(filter_var($composerTimeout, FILTER_VALIDATE_FLOAT));
 
         $process->start();
 

--- a/src/Composer/Command/ProcessCommand.php
+++ b/src/Composer/Command/ProcessCommand.php
@@ -53,9 +53,12 @@ abstract class ProcessCommand extends BaseCommand
             $this->getProcessCommand($input, $output),
             $this->getConfiguration()->getRepositoryRoot(),
         );
-        $composerTimeout = $this->getConfiguration()->getComposer()->getConfig()->get('process-timeout');
+        $composerTimeout = filter_var(
+            $this->getConfiguration()->getComposer()->getConfig()->get('process-timeout'),
+            FILTER_VALIDATE_FLOAT,
+        );
         if ($composerTimeout !== false) {
-            $process->setTimeout(filter_var($composerTimeout, FILTER_VALIDATE_FLOAT));
+            $process->setTimeout($composerTimeout);
         }
 
         $process->start();

--- a/src/Composer/Command/ProcessCommand.php
+++ b/src/Composer/Command/ProcessCommand.php
@@ -54,7 +54,9 @@ abstract class ProcessCommand extends BaseCommand
             $this->getConfiguration()->getRepositoryRoot(),
         );
         $composerTimeout = $this->getConfiguration()->getComposer()->getConfig()->get('process-timeout');
-        $process->setTimeout(filter_var($composerTimeout, FILTER_VALIDATE_FLOAT));
+        if ($composerTimeout !== false) {
+            $process->setTimeout(filter_var($composerTimeout, FILTER_VALIDATE_FLOAT));
+        }
 
         $process->start();
 

--- a/tests/Composer/Command/CommandTestCase.php
+++ b/tests/Composer/Command/CommandTestCase.php
@@ -28,6 +28,7 @@ abstract class CommandTestCase extends TestCase
 
     protected ?string $baseName = null;
     protected string $prefix = 'bar';
+    protected int $processTimeout = 300;
     protected string $binDir = '/path/to/bin-dir';
     protected string $repositoryRoot = '/path/to/repo';
 
@@ -60,6 +61,7 @@ abstract class CommandTestCase extends TestCase
         $commandClass = $this->commandClass;
 
         $this->config = $this->mockery(Config::class);
+        $this->config->allows()->get('process-timeout')->andReturn($this->processTimeout);
         $this->config->allows()->get('bin-dir')->andReturn($this->binDir);
 
         $this->eventDispatcher = $this->mockery(EventDispatcher::class);

--- a/tests/Composer/Command/LintPdsCommandTest.php
+++ b/tests/Composer/Command/LintPdsCommandTest.php
@@ -25,6 +25,7 @@ class LintPdsCommandTest extends ProcessCommandTestCase
     {
         /** @var Process & MockInterface $process */
         $process = $this->mockery(Process::class);
+        $process->allows('setTimeout');
         $process->expects()->start();
         $process
             ->shouldReceive('wait')

--- a/tests/Composer/Command/LintPdsCommandTest.php
+++ b/tests/Composer/Command/LintPdsCommandTest.php
@@ -25,7 +25,7 @@ class LintPdsCommandTest extends ProcessCommandTestCase
     {
         /** @var Process & MockInterface $process */
         $process = $this->mockery(Process::class);
-        $process->allows('setTimeout');
+        $process->expects('setTimeout');
         $process->expects()->start();
         $process
             ->shouldReceive('wait')

--- a/tests/Composer/Command/ProcessCommandTestCase.php
+++ b/tests/Composer/Command/ProcessCommandTestCase.php
@@ -55,6 +55,7 @@ abstract class ProcessCommandTestCase extends CommandTestCase
     {
         /** @var Process & MockInterface $process */
         $process = $this->mockery(Process::class);
+        $process->allows('setTimeout');
         $process->expects()->start();
         $process
             ->shouldReceive('wait')


### PR DESCRIPTION
## Description
This PR simply looks up the Composer defined process timeout value, filters it into a float and then sets the generated Symfony `Process` timeout value to match that.

This has two effective changes for end users:
1. Users setting a custom value in their `composer.json` for `process-timeout` get this value applied to each Process, and
2. The previous Symfony defined default `Process` timeout of `60s` is increased to match composers default `process-timeout` of `300s`.

## Motivation and context
This should solve: #83 

Currently it's possible for `dev:*` scripts to hit process timeouts based on Symfony's default 60s timeout. However the error that shows up is also appended with Composers help message about the `process-timeout` value.

Reviewing the error though it is obvious the composer default of 300s is not being hit, but rather the 60s default symfony uses is. See here:

```
The process "/home/runner/work/kickflip-src/kickflip-src/vendor/bin/phpunit '--colors=always'" exceeded the timeout of 60 seconds.
Check https://getcomposer.org/doc/06-config.md#process-timeout for details

                                                                                                                                      
  [Symfony\Component\Process\Exception\ProcessTimedOutException]                                                                      
  The process "/home/runner/work/kickflip-src/kickflip-src/vendor/bin/phpunit '--colors=always'" exceeded the timeout of 60 seconds. 
```

Rather than introduce a new option, or flag on commands, this PR opts to fix the issue by assigning the Symfony Process timeout the same value as composer's `process-timeout.

This way the timeout can be configured rather simply and the inconsistency with the error above fixed simply by making the system work the way the error implies. 

## How has this been tested?
I've tested my fork's branch via composer custom repositories setting. Doing so allowed me to confirm that the `composer.json` setting for `process-timeout` is being read and set on the generated process instance.

Before: [Test fails at 1m 6s](https://github.com/KickflipCli/kickflip-src/runs/4697463601?check_suite_focus=true) (Note: it's over 60s as it's GH run time not composers time)
After: [Test passes at 1m 24s](https://github.com/KickflipCli/kickflip-src/runs/4698270565?check_suite_focus=true) (Note: ignore the other failing tests, that's due to something else)

These seem to show that it's having the desired effect.

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING.md** document.
- [X] I have added tests to cover my changes.
