### PR TITLE
fix: add missed isTtySupported() method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,10 +39,10 @@
         "roave/security-advisories": "dev-latest",
         "symfony/filesystem": "^5.0 || ^6.0",
         "symfony/process": "^5.0 || ^6.0",
-        "vimeo/psalm": "^4.4"
+        "vimeo/psalm": "^4.22"
     },
     "require-dev": {
-        "composer/composer": "^1.10.22 || ^2.0.13"
+        "composer/composer": "^1.10.22 || >=2.0.13 <2.3"
     },
     "minimum-stability": "dev",
     "prefer-stable": true,

--- a/psalm.xml
+++ b/psalm.xml
@@ -2,7 +2,6 @@
 <psalm xmlns="https://getpsalm.org/schema/config"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
-       totallyTyped="true"
        cacheDirectory="./build/cache/psalm"
        errorBaseline="./psalm-baseline.xml">
 

--- a/src/Composer/Command/ProcessCommand.php
+++ b/src/Composer/Command/ProcessCommand.php
@@ -25,9 +25,9 @@ namespace Ramsey\Dev\Tools\Composer\Command;
 use ReflectionException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Process\Process;
 
 use function filter_var;
+use function proc_open;
 
 use const DIRECTORY_SEPARATOR;
 use const FILTER_VALIDATE_FLOAT;
@@ -65,12 +65,32 @@ abstract class ProcessCommand extends BaseCommand
             $process->setTimeout($composerTimeout);
         }
 
-        if (DIRECTORY_SEPARATOR !== '\\' && Process::isTtySupported()) {
+        if (DIRECTORY_SEPARATOR !== '\\' && self::isTtySupported()) {
             $process->setTty(true); // @codeCoverageIgnore
         }
 
         $process->start();
 
         return $process->wait($this->getProcessCallback($output));
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    private static function isTtySupported(): bool
+    {
+        static $isTtySupported;
+
+        if ($isTtySupported === null) {
+            $descriptors = [
+                ['file', '/dev/tty', 'r'],
+                ['file', '/dev/tty', 'w'],
+                ['file', '/dev/tty', 'w'],
+            ];
+
+            $isTtySupported = (bool) @proc_open('echo 1 >/dev/null', $descriptors, $pipes);
+        }
+
+        return $isTtySupported;
     }
 }


### PR DESCRIPTION
Fixes fatal error #90 by adding missed `isTtySupported()` method.

## Description
It copies the `isTtySupported()` static method from Symfony's `Process` to the abstract `ProcessCommand`.
Additionaly it excluded Composer >=2.3 from `composer.json` and removed the deprecated `totallyTyped` Psalm option.

## Motivation and context
Version 1.3.0 doesn't work with PHP 8.
Version 1.4.0 doesn't work at all.
I'd like to use devtools with PHP 8.
Fixes #90

## How has this been tested?
```
composer self-update --2.2
composer update
bin/devtools test:all
```

```
$ php --version
PHP 8.1.4 (cli) (built: Mar 29 2022 01:58:57) (NTS)
Copyright (c) The PHP Group
Zend Engine v4.1.4, Copyright (c) Zend Technologies
```

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [ ] I have added tests to cover my changes.
