### PR TITLE
fix: support of various PHP, Composer, and Symfony versions

### DIFF
--- a/bin/devtools
+++ b/bin/devtools
@@ -21,10 +21,10 @@
 
 declare(strict_types=1);
 
+use Composer\Console\Application;
 use Composer\Factory;
 use Composer\IO\ConsoleIO;
 use Ramsey\Dev\Tools\Composer\DevToolsPlugin;
-use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\ArgvInput;
 use Symfony\Component\Console\Input\StringInput;
@@ -66,7 +66,7 @@ use Symfony\Component\Console\Input\StringInput;
     $composerPlugin = new DevToolsPlugin();
     $composerPlugin->activate($composer, $io);
 
-    $application = new Application('ramsey/devtools');
+    $application = new Application();
     $application->addCommands($composerPlugin->getCommands());
     $application->run(new ArgvInput($argv));
 })($argv);

--- a/composer.json
+++ b/composer.json
@@ -39,7 +39,7 @@
         "roave/security-advisories": "dev-latest",
         "symfony/filesystem": "^5.0 || ^6.0",
         "symfony/process": "^5.0 || ^6.0",
-        "vimeo/psalm": "^4.4"
+        "vimeo/psalm": "^4.22"
     },
     "require-dev": {
         "composer/composer": "^1.10.22 || ^2.0.13"

--- a/psalm.xml
+++ b/psalm.xml
@@ -2,7 +2,6 @@
 <psalm xmlns="https://getpsalm.org/schema/config"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xsi:schemaLocation="https://getpsalm.org/schema/config vendor/vimeo/psalm/config.xsd"
-       totallyTyped="true"
        cacheDirectory="./build/cache/psalm"
        errorBaseline="./psalm-baseline.xml">
 

--- a/src/Composer/Command/BaseCommand.php
+++ b/src/Composer/Command/BaseCommand.php
@@ -23,14 +23,15 @@ declare(strict_types=1);
 namespace Ramsey\Dev\Tools\Composer\Command;
 
 use Composer\Command\BaseCommand as ComposerBaseCommand;
+use Composer\Console\Application;
 use Composer\EventDispatcher\EventDispatcher;
 use RuntimeException;
-use Symfony\Component\Console\Application;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
 use function assert;
 use function is_string;
+use function sprintf;
 use function substr;
 
 use const DIRECTORY_SEPARATOR;
@@ -128,17 +129,19 @@ abstract class BaseCommand extends ComposerBaseCommand
         return $this->getPrefix() . $name;
     }
 
-    /**
-     * @psalm-suppress MoreSpecificReturnType
-     * @psalm-suppress LessSpecificReturnStatement
-     */
     public function getApplication(): Application
     {
-        /** @var Application | null $application */
-        $application = parent::getApplication();
+        try {
+            $application = parent::getApplication();
+        } catch (RuntimeException $_e) {
+            $application = null;
+        }
 
-        if ($application === null) {
-            throw new RuntimeException('Could not find an Application instance');
+        if (!$application instanceof Application) {
+            throw new RuntimeException(sprintf(
+                'Composer commands can only work with an %s instance set',
+                Application::class,
+            ));
         }
 
         return $application;

--- a/src/Composer/Command/PreCommitCommand.php
+++ b/src/Composer/Command/PreCommitCommand.php
@@ -23,7 +23,6 @@ declare(strict_types=1);
 namespace Ramsey\Dev\Tools\Composer\Command;
 
 use Exception;
-use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
@@ -80,6 +79,6 @@ class PreCommitCommand extends BaseCommand
             OutputInterface::VERBOSITY_NORMAL,
         );
 
-        return Command::SUCCESS;
+        return 0;
     }
 }

--- a/src/Composer/Command/ProcessCommand.php
+++ b/src/Composer/Command/ProcessCommand.php
@@ -25,9 +25,9 @@ namespace Ramsey\Dev\Tools\Composer\Command;
 use ReflectionException;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Process\Process;
 
 use function filter_var;
+use function proc_open;
 
 use const DIRECTORY_SEPARATOR;
 use const FILTER_VALIDATE_FLOAT;
@@ -65,12 +65,33 @@ abstract class ProcessCommand extends BaseCommand
             $process->setTimeout($composerTimeout);
         }
 
-        if (DIRECTORY_SEPARATOR !== '\\' && Process::isTtySupported()) {
+        if (DIRECTORY_SEPARATOR !== '\\' && self::isTtySupported()) {
             $process->setTty(true); // @codeCoverageIgnore
         }
 
         $process->start();
 
         return $process->wait($this->getProcessCallback($output));
+    }
+
+    /**
+     * @codeCoverageIgnore
+     */
+    private static function isTtySupported(): bool
+    {
+        /** @var bool|null $isTtySupported */
+        static $isTtySupported;
+
+        if ($isTtySupported === null) {
+            $descriptors = [
+                ['file', '/dev/tty', 'r'],
+                ['file', '/dev/tty', 'w'],
+                ['file', '/dev/tty', 'w'],
+            ];
+
+            $isTtySupported = (bool) @proc_open('echo 1 >/dev/null', $descriptors, $pipes);
+        }
+
+        return $isTtySupported;
     }
 }

--- a/tests/Composer/Command/AnalyzeCommandTest.php
+++ b/tests/Composer/Command/AnalyzeCommandTest.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace Ramsey\Test\Dev\Tools\Composer\Command;
 
-use Composer\Console\Application;
 use Mockery\MockInterface;
 use Ramsey\Dev\Tools\Composer\Command\AnalyzeCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
 
@@ -49,11 +47,7 @@ class AnalyzeCommandTest extends CommandTestCase
         $input = new StringInput('');
         $output = new NullOutput();
 
-        /** @var Application & MockInterface $application */
-        $application = $this->mockery(Application::class, [
-            'getHelperSet' => $this->mockery(HelperSet::class),
-        ]);
-        $application->shouldReceive('getDefinition')->passthru();
+        $application = $this->mockApplication();
         $application
             ->expects()
             ->find($this->command->withPrefix('analyze:phpstan'))

--- a/tests/Composer/Command/CommandTestCase.php
+++ b/tests/Composer/Command/CommandTestCase.php
@@ -6,13 +6,16 @@ namespace Ramsey\Test\Dev\Tools\Composer\Command;
 
 use Composer\Composer;
 use Composer\Config;
+use Composer\Console\Application;
 use Composer\EventDispatcher\EventDispatcher;
+use Composer\IO\IOInterface;
 use Mockery\MockInterface;
 use Ramsey\Dev\Tools\Composer\Command\BaseCommand;
 use Ramsey\Dev\Tools\Composer\Command\Configuration;
 use Ramsey\Dev\Tools\Process\ProcessFactory;
 use Ramsey\Dev\Tools\TestCase;
 use RuntimeException;
+use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
 
@@ -128,7 +131,7 @@ abstract class CommandTestCase extends TestCase
         $this->command->setApplication(null);
 
         $this->expectException(RuntimeException::class);
-        $this->expectExceptionMessage('Could not find an Application instance');
+        $this->expectExceptionMessage('Composer commands can only work with an ');
 
         $this->command->getApplication();
     }
@@ -202,5 +205,22 @@ abstract class CommandTestCase extends TestCase
         $this->command = new $commandClass($configuration);
 
         $this->testRun();
+    }
+
+    /**
+     * @return Application & MockInterface
+     */
+    protected function mockApplication(): Application
+    {
+        $application = $this->mockery(Application::class, [
+            'getHelperSet' => $this->mockery(HelperSet::class),
+            'getIO' => $this->mockery(IOInterface::class),
+        ]);
+        $application->allows()->getDefinition()->passthru();
+        $application->allows()->setDefaultCommand('list')->passthru();
+
+        $application->setDefaultCommand('list');
+
+        return $application;
     }
 }

--- a/tests/Composer/Command/LintCommandTest.php
+++ b/tests/Composer/Command/LintCommandTest.php
@@ -4,11 +4,9 @@ declare(strict_types=1);
 
 namespace Ramsey\Test\Dev\Tools\Composer\Command;
 
-use Composer\Console\Application;
 use Mockery\MockInterface;
 use Ramsey\Dev\Tools\Composer\Command\LintCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
 
@@ -55,14 +53,7 @@ class LintCommandTest extends CommandTestCase
         $input = new StringInput('');
         $output = new NullOutput();
 
-        /** @var Application & MockInterface $application */
-        $application = $this->mockery(
-            Application::class,
-            [
-                'getHelperSet' => $this->mockery(HelperSet::class),
-            ],
-        );
-        $application->shouldReceive('getDefinition')->passthru();
+        $application = $this->mockApplication();
         $application
             ->expects()
             ->find($this->command->withPrefix('lint:syntax'))

--- a/tests/Composer/Command/LintSyntaxCommandTest.php
+++ b/tests/Composer/Command/LintSyntaxCommandTest.php
@@ -26,7 +26,7 @@ class LintSyntaxCommandTest extends ProcessCommandTestCase
 
         $this->input->allows()->getOption('parallel-lint-help')->andReturnFalse();
 
-        $this->input->allows()->getArguments()->andReturnNull();
+        $this->input->allows()->getArguments()->andReturn([]);
     }
 
     public function testWithParallelLintHelpOption(): void

--- a/tests/Composer/Command/TestAllCommandTest.php
+++ b/tests/Composer/Command/TestAllCommandTest.php
@@ -4,10 +4,8 @@ declare(strict_types=1);
 
 namespace Ramsey\Test\Dev\Tools\Composer\Command;
 
-use Composer\Console\Application;
 use Ramsey\Dev\Tools\Composer\Command\TestAllCommand;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Helper\HelperSet;
 use Symfony\Component\Console\Input\StringInput;
 use Symfony\Component\Console\Output\NullOutput;
 
@@ -51,10 +49,7 @@ class TestAllCommandTest extends CommandTestCase
         $input = new StringInput('');
         $output = new NullOutput();
 
-        $application = $this->mockery(Application::class, [
-            'getHelperSet' => $this->mockery(HelperSet::class),
-        ]);
-        $application->shouldReceive('getDefinition')->passthru();
+        $application = $this->mockApplication();
         $application
             ->expects()
             ->find($this->command->withPrefix('lint:all'))


### PR DESCRIPTION
It adds support of various PHP, Composer, and Symfony versions.

## Description
Different versions of composer depends on different versions of symfony/console, `devtools` runs in composer context and can conflict with project's version of symfony. I added support of all the relevant combinations.

## Motivation and context
I like that tool, but it didn't work with modern versions of PHP and Symfony.

## How has this been tested?
Tests are fixed and runs in matrix of:
- PHP 7.4, 8.0, 8.1
- Symfony 5.4, 6.0, 6.1
- composer 1, 2.2, 2.3, 2.4

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## PR checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING.md** document.
- [x] I have added tests to cover my changes.
