### PR TITLE
Docs: Update PHP_CodeSniffer repository link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ To see all the commands available for contributing to this project:
 ### Coding Standards
 
 This project follows a superset of [PSR-12](https://www.php-fig.org/psr/psr-12/)
-coding standards, enforced by [PHP_CodeSniffer](https://github.com/squizlabs/PHP_CodeSniffer).
+coding standards, enforced by [PHP_CodeSniffer](https://github.com/PHPCSStandards/PHP_CodeSniffer).
 
 CaptainHook will run coding standards checks before committing.
 

--- a/src/Command/Lint/FixCommand.php
+++ b/src/Command/Lint/FixCommand.php
@@ -110,7 +110,7 @@ final class FixCommand extends ProcessCommand
             should pass directly to phpcbf.
 
             For more information on phpcbf, see
-            <link>https://github.com/squizlabs/PHP_CodeSniffer</link>.
+            <link>https://github.com/PHPCSStandards/PHP_CodeSniffer</link>.
             EOD;
     }
 }

--- a/src/Command/Lint/StyleCommand.php
+++ b/src/Command/Lint/StyleCommand.php
@@ -85,7 +85,7 @@ final class StyleCommand extends ProcessCommand
             should pass directly to phpcs.
 
             For more information on phpcs, see
-            <link>https://github.com/squizlabs/PHP_CodeSniffer</link>.
+            <link>https://github.com/PHPCSStandards/PHP_CodeSniffer</link>.
             EOD;
     }
 }


### PR DESCRIPTION
PHP_CodeSniffer has moved to a new GitHub organization. The `squizlabs/PHP_CodeSniffer` repository is now archived and the project is actively maintained at https://github.com/PHPCSStandards/PHP_CodeSniffer.

See: https://github.com/squizlabs/PHP_CodeSniffer/issues/3932